### PR TITLE
Fix Raspberry Pi typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Photos Uploader
 
 SD カードの写真を Google Photos にアップロードしながら、スライドショーで表示するツールです。
-- TV などのディスプレイに接続した Raspberry Pi での動作を前提にしています。\*Rasberry Pi 5 で動作確認済み
+- TV などのディスプレイに接続した Raspberry Pi での動作を前提にしています。\*Raspberry Pi 5 で動作確認済み
 - 写真が格納されたフォルダ名が**DCIM**であることを前提にしています。
 
 ## 主な機能


### PR DESCRIPTION
## Summary
- fix Raspberry Pi spelling in docs

## Testing
- `grep -n Rasberry README.md`
