### PR TITLE
fix: correct Windows volume name comparison

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/src/google_photos_uploader/utils/__init__.py
+++ b/src/google_photos_uploader/utils/__init__.py
@@ -70,10 +70,10 @@ def find_sd_card(volume_name: str = "PHOTO_UPLOAD_SD") -> Optional[Path]:
         drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
         for drive in drives:
             try:
-                volume_name = win32api.GetVolumeInformation(drive)[0]
-                if volume_name == volume_name:
+                vol_name = win32api.GetVolumeInformation(drive)[0]
+                if vol_name == volume_name:
                     return Path(drive)
-            except:
+            except Exception:
                 continue
                 
     return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+import sys
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "src"))
+
+from google_photos_uploader.utils import find_sd_card
+
+
+def test_find_sd_card_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32", raising=False)
+
+    drives = ["C:\\", "E:\\"]
+
+    def mock_GetLogicalDriveStrings():
+        return "\000".join(drives) + "\000"
+
+    def mock_GetVolumeInformation(drive):
+        if drive == "C:\\":
+            return ("System", None, None, None, None)
+        elif drive == "E:\\":
+            return ("PHOTO_UPLOAD_SD", None, None, None, None)
+        raise OSError
+
+    mock_win32api = SimpleNamespace(
+        GetLogicalDriveStrings=mock_GetLogicalDriveStrings,
+        GetVolumeInformation=mock_GetVolumeInformation,
+    )
+    monkeypatch.setitem(sys.modules, "win32api", mock_win32api)
+
+    path = find_sd_card("PHOTO_UPLOAD_SD")
+    assert path == Path("E:\\")


### PR DESCRIPTION
## Summary
- fix comparison to use temporary variable when checking Windows volume name
- add unit test for find_sd_card on Windows
- configure pytest test discovery

## Testing
- `pytest -q`